### PR TITLE
drm/amdgpu: Propage amd_acquire errors in rdma_get_pages

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_peerdirect.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_peerdirect.c
@@ -564,6 +564,7 @@ static int rdma_get_pages(uint64_t address, uint64_t length, struct pid *pid,
 	kfd_unref_process(p);
 	if (r == 0) {
 		pr_debug("acquire failed: %d\n", r);
+		r = -EINVAL;
 		goto err_acquire;
 	}
 


### PR DESCRIPTION
amd_acquire returns 1 on success and 0 on failure. rdma_get_pages needs to return non-zero if amd_acquire fails.

Originally found by Chuck Fossen from HPE